### PR TITLE
Target builds on Windows to /MACHINE:X86, as X64 crashes compilation

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
     {".*", "ERL_LDFLAGS", " -L$ERL_EI_LIBDIR -lei"},
     {"(linux|darwin)", "CFLAGS", "$CFLAGS -O2 -finline-functions -fomit-frame-pointer -fno-strict-aliasing -Wmissing-prototypes -Wall -std=c99"},
     {"(linux|darwin)", "CXXFLAGS", "$CXXFLAGS -std=c++11"},
-    {"win32", "DRV_LINK_CXX_TEMPLATE", "$CC $ERL_CFLAGS $PORT_IN_FILES /link /DLL /MACHINE:X64 $DRV_LDFLAGS /OUT:$PORT_OUT_FILE"}
+    {"win32", "DRV_LINK_CXX_TEMPLATE", "$CC $ERL_CFLAGS $PORT_IN_FILES /link /DLL /MACHINE:X86 $DRV_LDFLAGS /OUT:$PORT_OUT_FILE"}
 ]}.
 
 


### PR DESCRIPTION
Target builds on Windows to /MACHINE:X86, as X64 crashes compilation